### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
         "Subdomain Center": "https://subdomain.center",
         "Exploit Observer": "https://exploit.observer",
     },
+    license="MIT",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     description="The Panthera(P.)uncia of Cybersecurity - Official CLI utility for Subdomain Center & Exploit Observer",


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.